### PR TITLE
fix Makefile and touch.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,43 @@
+.POSIX:
+
+XCFLAGS = -std=c99 -D_DEFAULT_SOURCE ${CFLAGS}
+
 all: ls cp mv touch cat sleep stat grep du chroot uname
 
 ls:
-	gcc ls.c -o ls
+	gcc ${XCFLAGS} ls.c -o ls
 
 cp:
-	gcc cp.c -o cp
+	gcc ${XCFLAGS} cp.c -o cp
 
 mv:
-	gcc mv.c -o mv
+	gcc ${XCFLAGS} mv.c -o mv
 
 touch:
-	gcc touch.c -o touch
+	gcc ${XCFLAGS} touch.c -o touch
 
 cat:
-	gcc cat.c -o cat
+	gcc ${XCFLAGS} cat.c -o cat
 
 sleep:
-	gcc sleep.c -o sleep
+	gcc ${XCFLAGS} sleep.c -o sleep
 
 stat:
-	gcc stat.c -o stat
+	gcc ${XCFLAGS} stat.c -o stat
 
 grep:
-	gcc grep.c -o grep
+	gcc ${XCFLAGS} grep.c -o grep
 
 du:
-	gcc du.c -o du
+	gcc ${XCFLAGS} du.c -o du
 
 chroot:
-	gcc chroot.c -o chroot
+	gcc ${XCFLAGS} chroot.c -o chroot
 
 uname:
-	gcc uname.c -o uname
+	gcc ${XCFLAGS} uname.c -o uname
+
+clean:
+	rm -f ls cp mv touch cat sleep stat grep du chroot uname
+
+.PHONY: all clean

--- a/cp.c
+++ b/cp.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
 	printf("Copiying %s to %s\n", origin, destination);
 
 	int copyFd = open(origin, O_RDONLY);
-	int destFd = open(destination, O_WRONLY| O_TRUNC | O_CREAT);
+	int destFd = open(destination, O_WRONLY| O_TRUNC | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
 
 	struct stat stats;
 	fstat(copyFd, &stats);

--- a/mv.c
+++ b/mv.c
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
 	printf("Moving %s to %s\n", argv[1], argv[2]);
 
 	int copyFd = open(argv[1], O_RDONLY);
-	int destFd = open(argv[2], O_WRONLY| O_TRUNC | O_CREAT);
+	int destFd = open(argv[2], O_WRONLY| O_TRUNC | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
 
 	struct stat stats;
 	fstat(copyFd, &stats);

--- a/touch.c
+++ b/touch.c
@@ -1,17 +1,18 @@
-#include <stdio.h>
 #include <unistd.h>
-#include <dirent.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <time.h>
+#include <utime.h>
 
 int main(int argc, char **argv) {
 	if (argc != 2) return -1;
-	
-	int destFd = open(argv[1], O_CREAT);
-	fchmod(destFd, 644);
+
+	int destFd = open(argv[1], O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
 
 	close(destFd);
+
+	time_t _time = time(NULL);
+
+	utime(argv[1], &(const struct utimbuf){.actime = _time, .modtime = _time});
 
 	return 0;
 }


### PR DESCRIPTION
The Makefile didn't respect CFLAGS, and all builds were unoptimized.
This allowed some errors to slip through the cracks, like open called with O_CREAT, but no mode, which is a build error when making an optimized build.

Also added a phony clean target, marked the all target as phony, and turned the make the makefile a posix C99 Makefile, because the code complies to the needed standards.

In touch.c, permissions in decimal(base 10) notation were passed to fchmod, which expects octal(base 8) notation. There are macros that specify the file mode that I used for this.
Also, touch.c used 644 permissions for created files, and changed existing files to 644.
I modified it to only set permissions of created files to 664, which is what gnu touch uses.